### PR TITLE
Add option to filter commits by deploy context

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This action uses the Netlify API to always retrieve the correct deployment being
 
 Optional — The amount of time to spend waiting on the Netlify deployment to respond with a success HTTP code after reaching "ready" status. Defaults to 60 seconds.
 
+### `context`
+
+Optional — The Netlify deploy context. Can be `branch-deploy`, `production` or `deploy-preview`. Defaults to all of them.
+
 ## Outputs
 
 ### `url`
@@ -43,7 +47,7 @@ steps:
       site_id: 'YOUR_SITE_ID' # See Settings > Site Details > General in the Netlify UI
     env:
       NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
-      
+
 # Then use it in a later step like:
 # ${{ steps.waitForDeployment.outputs.url }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   max_timeout:
     description: "The max time to wait after the deployment is ready for a valid HTTP status code."
     required: false
+  context:
+    description: "The Netlify deploy context. Can be branch-deploy, production or deploy-preview."
+    required: false
 outputs:
   deploy_id:
     description: "The Netlify deployment ID"


### PR DESCRIPTION
I have Netlify build & deploy set up as:
- Branches:
    - Production branch: master
    - Branch deploys: Deploy all branches pushed to the repository
- Deploy Previews
    - Any pull request against your production branch / branch deploy branches

When pushing to `master`, a build is triggered on Netlify, and I have a GitHub Action that creates a tag for a new release at the same time. The next step is to wait for Netlify. The tag triggers a build with the exact same git sha as the push to `master` and without a context, `wait-for-netlify-action` is waiting for the tag branch deploy build, but it should be waiting for the `master` production build.

This PR adds a new input to the action that lets users additionally filter the searched build by the deploy context.